### PR TITLE
Users can now specify a `tests` directory where to look for tests

### DIFF
--- a/svut/svutRun.py
+++ b/svut/svutRun.py
@@ -124,7 +124,7 @@ def find_unit_tests():
     files = list(set(files))
 
     if not files:
-        print("ERROR: Can't find tests to unr")
+        print("ERROR: Can't find tests to run")
         sys.exit(1)
 
     return files

--- a/svut/svutRun.py
+++ b/svut/svutRun.py
@@ -78,7 +78,6 @@ def check_tb_extension(test : PosixPath):
     """
     Check the extension to be sure it can be run
     """
-    print("BLAA", test)
     if test.suffix not in [".v",".sv"]:
         print("ERROR: Failed to find supported extension. Must use either *.v or *.sv")
         sys.exit(1)
@@ -318,7 +317,6 @@ def get_git_tag():
     except subprocess.CalledProcessError as err:
         print("WARNING: Can't get last git tag. Will return v0.0.0")
         git_tag = "v0.0.0"
-        print(err.output)
 
     os.chdir(curr_path)
     return git_tag


### PR DESCRIPTION
I've created support for specifying a path where tests are located. This is for people who separate their `src` and `tests` file. 

It checks if `-test` parameter contains one item and is a path. It will then use that path to resolve test. The default behavior of using the CWD if the parameter is not specified is maintained.