### PR TITLE
add line number in message

### DIFF
--- a/svut/svut_h.sv
+++ b/svut/svut_h.sv
@@ -54,29 +54,29 @@
 /// and information with an appropriate color.
 
 `define MSG(msg) \
-    $display("\033[0;37m%s (@ %0t)\033[0m", msg, $realtime)
+    $display("\033[0;37m%s (L%0d @ %0t)\033[0m", msg, `__LINE__, $realtime)
 
 `define INFO(msg) \
-    $display("\033[0;34mINFO: %s (@ %0t)\033[0m", msg, $realtime)
+    $display("\033[0;34mINFO: %s (L%0d @ %0t)\033[0m", msg, `__LINE__, $realtime)
 
 `define SUCCESS(msg) \
-    $display("\033[0;32mSUCCESS: %s (@ %0t)\033[0m", msg, $realtime)
+    $display("\033[0;32mSUCCESS: %s (L%0d @ %0t)\033[0m", msg, `__LINE__, $realtime)
 
 `define WARNING(msg) \
     begin\
-    $display("\033[1;33mWARNING: %s (@ %0t)\033[0m", msg, $realtime);\
+    $display("\033[1;33mWARNING: %s (L%0d @ %0t)\033[0m", msg, `__LINE__, $realtime);\
     svut_warning += 1;\
     end
 
 `define CRITICAL(msg) \
     begin\
-    $display("\033[1;35mCRITICAL: %s (@ %0t)\033[0m", msg, $realtime);\
+    $display("\033[1;35mCRITICAL: %s (L%0d @ %0t)\033[0m", msg, `__LINE__, $realtime);\
     svut_critical += 1;\
     end
 
 `define ERROR(msg)\
     begin\
-    $display("\033[1;31mERROR: %s (@ %0t)\033[0m", msg, $realtime);\
+    $display("\033[1;31mERROR: %s (L%0d @ %0t)\033[0m", msg, `__LINE__, $realtime);\
     svut_error += 1;\
     end
 


### PR DESCRIPTION
Show line number in log messages. This is useful especially for warn/error/critical messages.