### PR TITLE
concat filename and line number with colon for better redirection

### DIFF
--- a/svut/svut_h.sv
+++ b/svut/svut_h.sv
@@ -54,29 +54,29 @@
 /// and information with an appropriate color.
 
 `define MSG(msg) \
-    $display("\033[0;37m%s (@ %0t) (L%0d %s)\033[0m", msg, $realtime, `__LINE__, `__FILE__)
+    $display("\033[0;37m%s (@ %0t) (%s:%0d)\033[0m", msg, $realtime, `__FILE__, `__LINE__)
 
 `define INFO(msg) \
-    $display("\033[0;34mINFO: %s (@ %0t) (L%0d %s)\033[0m", msg, $realtime, `__LINE__, `__FILE__)
+    $display("\033[0;34mINFO: %s (@ %0t) (%s:%0d)\033[0m", msg, $realtime, `__FILE__, `__LINE__)
 
 `define SUCCESS(msg) \
-    $display("\033[0;32mSUCCESS: %s (@ %0t) (L%0d %s)\033[0m", msg, $realtime, `__LINE__, `__FILE__)
+    $display("\033[0;32mSUCCESS: %s (@ %0t) (%s:%0d)\033[0m", msg, $realtime, `__FILE__, `__LINE__)
 
 `define WARNING(msg) \
     begin\
-    $display("\033[1;33mWARNING: %s (@ %0t) (L%0d %s)\033[0m", msg, $realtime, `__LINE__, `__FILE__);\
+    $display("\033[1;33mWARNING: %s (@ %0t) (%s:%0d)\033[0m", msg, $realtime, `__FILE__, `__LINE__);\
     svut_warning += 1;\
     end
 
 `define CRITICAL(msg) \
     begin\
-    $display("\033[1;35mCRITICAL: %s (@ %0t) (L%0d %s)\033[0m", msg, $realtime, `__LINE__, `__FILE__);\
+    $display("\033[1;35mCRITICAL: %s (@ %0t) (%s:%0d)\033[0m", msg, $realtime, `__FILE__, `__LINE__);\
     svut_critical += 1;\
     end
 
 `define ERROR(msg)\
     begin\
-    $display("\033[1;31mERROR: %s (@ %0t) (L%0d %s)\033[0m", msg, $realtime, `__LINE__, `__FILE__);\
+    $display("\033[1;31mERROR: %s (@ %0t) (%s:%0d)\033[0m", msg, $realtime, `__FILE__, `__LINE__);\
     svut_error += 1;\
     end
 


### PR DESCRIPTION
Thanks for adopting previous pull request.

I noticed that the filename is also added to the message. And I come up with this further improvement. So that we can make redirection to source code line by "Cmd+Click" on editors such as VSCode.

The following is the sample output:

```
INFO: Start testsuite << FFD Testsuite >> (@ 0) (ffd_testbench.sv:53)

INFO: Starting << Test 0: Check reset is applied >> (@ 0) (ffd_testbench.sv:74)
I will test if Q output is 0 after reset (@ 100000) (ffd_testbench.sv:76)
SUCCESS: Test 0 pass (@ 110000) (ffd_testbench.sv:81)

INFO: Starting << Test 1: Drive the FFD >> (@ 110000) (ffd_testbench.sv:83)
I will test if Q output is 1 after D assertion (@ 210000) (ffd_testbench.sv:85)
SUCCESS: Test 1 pass (@ 236000) (ffd_testbench.sv:94)

INFO: Stop testsuite 'FFD Testsuite' (@ 236000) (ffd_testbench.sv:96)
  - Warning number:  0
  - Critical number: 0
  - Error number:    0
  - STATUS: 2/2 test(s) passed

ffd_testbench.sv:118: $finish called at 236000 (1ps)
SVUT (@ 22:47:49) Stop ffd_testbench.sv

SVUT (@ 22:47:49) Elapsed time: 0:00:00.087769
```