### PR TITLE
Fix macro operator precedence problem

### DIFF
--- a/svut/svut_h.sv
+++ b/svut/svut_h.sv
@@ -129,7 +129,7 @@ endfunction
 `define FAIL_IF_NOT(exp, message="") \
     svut_status = 0; \
     svut_msg = create_msg("FAIL_IF_NOT", message); \
-    if (!exp) begin \
+    if (!(exp)) begin \
         `ERROR(svut_msg); \
         svut_status = 1; \
     end
@@ -156,7 +156,7 @@ endfunction
 `define ASSERT(exp, message="") \
     svut_status = 0; \
     svut_msg = create_msg("ASSERT", message); \
-    if (!exp) begin \
+    if (!(exp)) begin \
         `ERROR(svut_msg); \
         svut_status = 1; \
     end

--- a/svut/template.sv
+++ b/svut/template.sv
@@ -51,7 +51,7 @@ ${module_inst}
     //    - `FAIL_IF_EQUAL(aSignal, 23):       Increment error counter if evaluation is equal
     //    - `FAIL_IF_NOT_EQUAL(aSignal, 45):   Increment error counter if evaluation is not equal
     //    - `ASSERT(aSignal):                  Increment error counter if evaluation is not true
-    //    - `ASSERT((aSignal == 0)):           Increment error counter if evaluation is not true
+    //    - `ASSERT(aSignal == 0):           Increment error counter if evaluation is not true
     //
     //  Available flag:
     //

--- a/test/Adder_KO_testsuite.sv
+++ b/test/Adder_KO_testsuite.sv
@@ -95,6 +95,8 @@ module Adder_unit_test_KO;
         `FAIL_IF_NOT_EQUAL(out, 8'd0);
         `INFO("Test FAIL_IF_NOT_EQUAL");
         `FAIL_IF_EQUAL(out, 8'd1);
+        `INFO("Test ASSERT");
+        `ASSERT(inc === 1'b1);
 
         `ERROR("Test finished");
 

--- a/test/Adder_OK_testsuite.sv
+++ b/test/Adder_OK_testsuite.sv
@@ -98,6 +98,8 @@ module Adder_unit_test_OK;
         `FAIL_IF_EQUAL(out, 8'd0);
         `INFO("Test FAIL_IF_NOT_EQUAL");
         `FAIL_IF_NOT_EQUAL(out, 8'd1);
+        `INFO("Test ASSERT");
+        `ASSERT(inc === 1'b0);
 
         `SUCCESS("Test finished");
 

--- a/test/testsuite_run.sh
+++ b/test/testsuite_run.sh
@@ -20,7 +20,7 @@ test_run_ko_testsuite() { #@test
 test_run_ko_testsuite_error_count() { #@test
 
     run exe_ko_to_log
-    error_num=9
+    error_num=10
     [ $(grep -c "ERROR:" log) -eq "$error_num" ]
 }
 


### PR DESCRIPTION
# Description

This PR fixes the macro operator precedence problem mentioned in #29. It ensures correct operator precedence in assertions to prevent logical errors caused by missing parentheses.

# Changes

- Wrapped `exp` with parentheses in macros such as `ASSERT` and `FAIL_IF_NOT`.
- Added `ASSERT` to macro tests in two system verilog testsuites.

# Note

Feel free to squash the commits during the merge if preferred.
